### PR TITLE
feat: Complete Tally implementation

### DIFF
--- a/backend/src/dykm/lib_api_response.go
+++ b/backend/src/dykm/lib_api_response.go
@@ -15,9 +15,9 @@ type Tally struct {
     Ips       int `json:"ips"`
     Names     int `json:"names"`
     Passwords int `json:"passwords"`
-    Addresses  int `json:"addresses"`
-    Companies  int `json:"companies"`
-    Other      int `json:"other"`
+    Addresses int `json:"addresses"`
+    Companies int `json:"companies"`
+    Other     int `json:"other"`
 }
 
 // Serializes a Tally to a JSON string, returning
@@ -62,16 +62,16 @@ func TallyFromJson(json_string string) Result[Tally] {
 func (tally1 Tally) add(tally2 Tally) Tally {
 	return Tally{
 		Usernames: tally1.Usernames + tally2.Usernames,
-		Emails:    tally1.Emails + tally2.Emails,
-		Phones:    tally1.Phones + tally2.Phones,
-		Hashes:    tally1.Hashes + tally2.Hashes,
-		Salts:     tally1.Salts + tally2.Salts,
-		Ips:       tally1.Ips + tally2.Ips,
-		Names:     tally1.Names + tally2.Names,
+		Emails:    tally1.Emails    + tally2.Emails,
+		Phones:    tally1.Phones    + tally2.Phones,
+		Hashes:    tally1.Hashes    + tally2.Hashes,
+		Salts:     tally1.Salts     + tally2.Salts,
+		Ips:       tally1.Ips       + tally2.Ips,
+		Names:     tally1.Names     + tally2.Names,
 		Passwords: tally1.Passwords + tally2.Passwords,
 		Addresses: tally1.Addresses + tally2.Addresses,
 		Companies: tally1.Companies + tally2.Companies,
-		Other:     tally1.Other + tally2.Other,
+		Other:     tally1.Other     + tally2.Other,
 	};
 }
 

--- a/backend/src/dykm/lib_api_response.go
+++ b/backend/src/dykm/lib_api_response.go
@@ -44,11 +44,10 @@ func (tally Tally) JSONString() string {
 
 // Deserializes a Tally from a JSON string, returning
 //  a Result containing the Tally or an error
-func TallyFromJson(json_string string) Result[Tally] {
+func TallyFromJSON(json_string string) Result[Tally] {
 	res := Tally{};
-	str := `{"usernames": 1, "emails": 2, "phones": 3, "hashes": 4, "salts": 5, "ips": 6, "names": 7, "passwords": 8, "addresses": 9, "companies": 10, "other": 11}`;
 	
-	err := json.Unmarshal([]byte(str), &res);
+	err := json.Unmarshal([]byte(json_string), &res);
 
 	if err != nil {
 		return Err[Tally]( "Failed to deserialize: " + err.Error() );

--- a/backend/src/dykm/lib_api_response.go
+++ b/backend/src/dykm/lib_api_response.go
@@ -2,7 +2,6 @@ package main;
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 );
 
@@ -49,16 +48,11 @@ func TallyFromJson(json_string string) Result[Tally] {
 	res := Tally{};
 	str := `{"usernames": 1, "emails": 2, "phones": 3, "hashes": 4, "salts": 5, "ips": 6, "names": 7, "passwords": 8, "addresses": 9, "companies": 10, "other": 11}`;
 	
-    fmt.Println(res)
-	
 	err := json.Unmarshal([]byte(str), &res);
 
 	if err != nil {
 		return Err[Tally]( "Failed to deserialize: " + err.Error() );
 	}
-
-    fmt.Println(res)
-	fmt.Println("Deserialized tally: ");
 
 	return Ok( res );
 }

--- a/backend/src/dykm/lib_api_response.go
+++ b/backend/src/dykm/lib_api_response.go
@@ -1,18 +1,21 @@
 package main;
 
 // Represents the final tally of for the PII that was requested
-type APIResponse struct {
-	email    int8;
-	phone    int8;
-	username int8;
-	ip       int8;
-	password int8;
-	name     int8;
-	hash     int8;
-	total    int8;
+type Tally struct {
+	usernames int32;
+	emails    int32;
+	phones    int32;
+	hashes    int32;
+	salts     int32;
+	ips       int32;
+	names     int32;
+	passwords int32;
+	addresses int32;
+	companies int32;
+	other     int32;
 };
 
 // Converts an APIResponse to a human-readable string
-func (response APIResponse) String() string {
-	return "HELLO CHAT";
+func (response Tally) String() string {
+	return "todo!();";
 };

--- a/backend/src/dykm/lib_api_response.go
+++ b/backend/src/dykm/lib_api_response.go
@@ -15,6 +15,23 @@ type Tally struct {
 	other     int32;
 };
 
+// Adds two Tallys together.
+func (tally1 Tally) add(tally2 Tally) Tally {
+	return Tally{
+		usernames: tally1.usernames + tally2.usernames,
+		emails:    tally1.emails + tally2.emails,
+		phones:    tally1.phones + tally2.phones,
+		hashes:    tally1.hashes + tally2.hashes,
+		salts:     tally1.salts + tally2.salts,
+		ips:       tally1.ips + tally2.ips,
+		names:     tally1.names + tally2.names,
+		passwords: tally1.passwords + tally2.passwords,
+		addresses: tally1.addresses + tally2.addresses,
+		companies: tally1.companies + tally2.companies,
+		other:     tally1.other + tally2.other,
+	};
+}
+
 // Converts an APIResponse to a human-readable string
 func (response Tally) String() string {
 	return "todo!();";

--- a/backend/src/dykm/lib_api_response.go
+++ b/backend/src/dykm/lib_api_response.go
@@ -1,38 +1,89 @@
 package main;
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+);
+
 // Represents the final tally of for the PII that was requested
 type Tally struct {
-	usernames int32;
-	emails    int32;
-	phones    int32;
-	hashes    int32;
-	salts     int32;
-	ips       int32;
-	names     int32;
-	passwords int32;
-	addresses int32;
-	companies int32;
-	other     int32;
-};
+    Usernames int `json:"usernames"`
+    Emails    int `json:"emails"`
+    Phones    int `json:"phones"`
+    Hashes    int `json:"hashes"`
+    Salts     int `json:"salts"`
+    Ips       int `json:"ips"`
+    Names     int `json:"names"`
+    Passwords int `json:"passwords"`
+    Addresses  int `json:"addresses"`
+    Companies  int `json:"companies"`
+    Other      int `json:"other"`
+}
+
+// Serializes a Tally to a JSON string, returning
+//  a Result containing the JSON string or an error
+func (tally Tally) JSONString() string {
+	var body string = "{";
+
+	body += "\"usernames\": " + strconv.Itoa(tally.Usernames) + ", ";
+	body += "\"emails\": "    + strconv.Itoa(tally.Emails)    + ", ";
+	body += "\"phones\": "    + strconv.Itoa(tally.Phones)    + ", ";
+	body += "\"hashes\": "    + strconv.Itoa(tally.Hashes) 	  + ", ";
+	body += "\"salts\": "     + strconv.Itoa(tally.Salts) 	  + ", ";
+	body += "\"ips\": " 	  + strconv.Itoa(tally.Ips) 	  + ", ";
+	body += "\"names\": "     + strconv.Itoa(tally.Names) 	  + ", ";
+	body += "\"passwords\": " + strconv.Itoa(tally.Passwords) + ", ";
+	body += "\"addresses\": " + strconv.Itoa(tally.Addresses) + ", ";
+	body += "\"companies\": " + strconv.Itoa(tally.Companies) + ", ";
+	body += "\"other\": "     + strconv.Itoa(tally.Other);
+
+	body += "}";
+
+	return body;
+}
+
+// Deserializes a Tally from a JSON string, returning
+//  a Result containing the Tally or an error
+func TallyFromJson(json_string string) Result[Tally] {
+	res := Tally{};
+	str := `{"usernames": 1, "emails": 2, "phones": 3, "hashes": 4, "salts": 5, "ips": 6, "names": 7, "passwords": 8, "addresses": 9, "companies": 10, "other": 11}`;
+	
+    fmt.Println(res)
+	
+	err := json.Unmarshal([]byte(str), &res);
+
+	if err != nil {
+		return Err[Tally]( "Failed to deserialize: " + err.Error() );
+	}
+
+    fmt.Println(res)
+	fmt.Println("Deserialized tally: ");
+
+	return Ok( res );
+}
+
 
 // Adds two Tallys together.
 func (tally1 Tally) add(tally2 Tally) Tally {
 	return Tally{
-		usernames: tally1.usernames + tally2.usernames,
-		emails:    tally1.emails + tally2.emails,
-		phones:    tally1.phones + tally2.phones,
-		hashes:    tally1.hashes + tally2.hashes,
-		salts:     tally1.salts + tally2.salts,
-		ips:       tally1.ips + tally2.ips,
-		names:     tally1.names + tally2.names,
-		passwords: tally1.passwords + tally2.passwords,
-		addresses: tally1.addresses + tally2.addresses,
-		companies: tally1.companies + tally2.companies,
-		other:     tally1.other + tally2.other,
+		Usernames: tally1.Usernames + tally2.Usernames,
+		Emails:    tally1.Emails + tally2.Emails,
+		Phones:    tally1.Phones + tally2.Phones,
+		Hashes:    tally1.Hashes + tally2.Hashes,
+		Salts:     tally1.Salts + tally2.Salts,
+		Ips:       tally1.Ips + tally2.Ips,
+		Names:     tally1.Names + tally2.Names,
+		Passwords: tally1.Passwords + tally2.Passwords,
+		Addresses: tally1.Addresses + tally2.Addresses,
+		Companies: tally1.Companies + tally2.Companies,
+		Other:     tally1.Other + tally2.Other,
 	};
 }
 
+/*
 // Converts an APIResponse to a human-readable string
 func (response Tally) String() string {
 	return "todo!();";
 };
+*/

--- a/backend/src/dykm/lib_optionals.go
+++ b/backend/src/dykm/lib_optionals.go
@@ -3,13 +3,14 @@ package main;
 // Represents an optional type which can contain an error
 type Result[T any] struct {
 	is_ok bool;
-	value T;
+	ok_value T;
+	err_value string;
 }
 func Ok[T any](value T) Result[T] {
-	return Result[T]{is_ok: true, value: value};
+	return Result[T]{is_ok: true, ok_value: value};
 }
-func Err[T any](value T) Result[T] {
-	return Result[T]{is_ok: false, value: value};
+func Err[T any](value string) Result[T] {
+	return Result[T]{is_ok: false, err_value: value};
 }
 func is_ok[T any](result Result[T]) bool {
 	return result.is_ok;
@@ -17,16 +18,16 @@ func is_ok[T any](result Result[T]) bool {
 func is_err[T any](result Result[T]) bool {
 	return !result.is_ok;
 }
-func unwrap_ok[T any](result Result[T]) T {
+func (result Result[T]) unwrap_ok() T {
 	if is_ok(result) {
-		return result.value;
+		return result.ok_value;
 	}
 
 	panic("Attempted to unwrap an error");
 }
-func unwrap_err[T any](result Result[T]) T {
+func (result Result[T]) unwrap_err() string {
 	if is_err(result) {
-		return result.value;
+		return result.err_value;
 	}
 
 	panic("Attempted to get an error from an Ok result");

--- a/backend/src/dykm/lib_test.go
+++ b/backend/src/dykm/lib_test.go
@@ -1,0 +1,30 @@
+package main;
+
+import (
+	"log"
+	"testing"
+	"strconv"
+);
+
+func TestSerializationCycleEquivalence ( t *testing.T ) {
+	serialized_json := "{\"usernames\": 1, \"emails\": 2, \"phones\": 3, \"hashes\": 4, \"salts\": 5, \"ips\": 6, \"names\": 7, \"passwords\": 8, \"addresses\": 9, \"companies\": 10, \"other\": 11}";
+		
+	tally_result := TallyFromJson(serialized_json);
+	if is_err(tally_result) {
+		t.Fatal("Failed to deserialize Tally: " + tally_result.unwrap_err());
+	}
+	tally := tally_result.unwrap_ok();
+
+	log.Println("Deserialized Tally: ");
+	log.Println(strconv.Itoa(tally.Usernames));
+	log.Println(strconv.Itoa(tally.Emails));
+	log.Println(strconv.Itoa(tally.Phones));
+
+	serialized_tally := tally.JSONString();
+	log.Println("Reserialized Ttally: " + serialized_tally);
+
+	log.Println("Are the two tallies equal?");
+	if serialized_json != serialized_tally {
+		t.Fatal("The two tallies are not equal");
+	}
+}


### PR DESCRIPTION
Adds all features you will need to be able to write the API interface, allowing you to quickly serialize and deserialize the `Tally` type for any purpose.

Also adds the ability to add `Tally`s together for convenience.

Since this is the exact format that I wrote the OSINT proxy API to output regardless of target API, you should be able to directly deserialize any API call to this type.